### PR TITLE
feat: make social buttons match renku style (#6)

### DIFF
--- a/renku_theme/login/resources/css/login.css
+++ b/renku_theme/login/resources/css/login.css
@@ -243,6 +243,27 @@ div#kc-social-providers ul li span {
     width: 100px;
 }
 
+.zocial.acrobat,
+.zocial.bitcoin,
+.zocial.cloudapp,
+.zocial.dropbox,
+.zocial.email,
+.zocial.eventful,
+.zocial.github,
+.zocial.gmail,
+.zocial.instapaper,
+.zocial.itunes,
+.zocial.ninetyninedesigns,
+.zocial.openid,
+.zocial.plancast,
+.zocial.pocket,
+.zocial.posterous,
+.zocial.reddit,
+.zocial.secondary,
+.zocial.stackoverflow,
+.zocial.viadeo,
+.zocial.weibo,
+.zocial.wikipedia,
 a.zocial {
     font-family: Calcutta, sans-serif;
 
@@ -263,7 +284,73 @@ a.zocial {
     border-radius: 0;
 }
 
+
+.zocial.acrobat:focus,
+.zocial.acrobat:hover,
+.zocial.bitcoin:focus,
+.zocial.bitcoin:hover,
+.zocial.dropbox:focus,
+.zocial.dropbox:hover,
+.zocial.email:focus,
+.zocial.email:hover,
+.zocial.eventful:focus,
+.zocial.eventful:hover,
+.zocial.github:focus,
+.zocial.github:hover,
+.zocial.gmail:focus,
+.zocial.gmail:hover,
+.zocial.instapaper:focus,
+.zocial.instapaper:hover,
+.zocial.itunes:focus,
+.zocial.itunes:hover,
+.zocial.ninetyninedesigns:focus,
+.zocial.ninetyninedesigns:hover,
+.zocial.openid:focus,
+.zocial.openid:hover,
+.zocial.plancast:focus,
+.zocial.plancast:hover,
+.zocial.pocket:focus,
+.zocial.pocket:hover,
+.zocial.posterous:focus,
+.zocial.posterous:hover,
+.zocial.reddit:focus,
+.zocial.reddit:hover,
+.zocial.secondary:focus,
+.zocial.secondary:hover,
+.zocial.stackoverflow:focus,
+.zocial.stackoverflow:hover,
+.zocial.twitter:focus,
+.zocial.viadeo:focus,
+.zocial.viadeo:hover,
+.zocial.weibo:focus,
+.zocial.weibo:hover,
+.zocial.wikipedia:focus,
+.zocial.wikipedia:hover,
 a.zocial:hover {
+    background: #009568;
+    color: #FFFFFF
+}
+
+.zocial.acrobat:active,
+.zocial.bitcoin:active,
+.zocial.dropbox:active,
+.zocial.email:active,
+.zocial.eventful:active,
+.zocial.github:active,
+.zocial.gmail:active,
+.zocial.instapaper:active,
+.zocial.itunes:active,
+.zocial.ninetyninedesigns:active,
+.zocial.openid:active,
+.zocial.plancast:active,
+.zocial.pocket:active,
+.zocial.posterous:active,
+.zocial.reddit:active,
+.zocial.secondary:active,
+.zocial.stackoverflow:active,
+.zocial.viadeo:active,
+.zocial.weibo:active,
+.zocial.wikipedia:active {
     background: #009568;
     color: #FFFFFF
 }


### PR DESCRIPTION
Fix #6

# Screenshots

![image](https://user-images.githubusercontent.com/1196411/135980887-e5ee0359-7872-4882-9f1f-cfca60c45d49.png)

With mouseover

![image](https://user-images.githubusercontent.com/1196411/135980942-b0aec79f-0ac6-4fec-9418-a81a2b76f188.png)

Note: The problem with the alignment of text with the icon is a general problem. The typeface we are using has a non-standard baseline. We need to talk to the designer about how to handle this.

# Testing

I do not think it is really necessary to test, but if you want to it is not to difficult, it just requires a bit of set-up.

You need to create a new OAuth App on the GitHub Developer Settings page: https://github.com/settings/developers

Set the homepage URL to `http://localhost:8080/` and the authorization callback to `http://localhost:8080/auth/realms/renku/broker/github/endpoint`. After setting it up, you need to generate a client secret.

Then, follow the instructions in the README to use the Dockerfile.dev to run a keycoak instance on your computer. In that instance, set up a GitHub identity provider and enter the client ID and client secret from GitHub.



