### PR TITLE
fix: replace Keycloak background with Renku bg color

### DIFF
--- a/renku_theme/login/resources/css/login.css
+++ b/renku_theme/login/resources/css/login.css
@@ -17,6 +17,10 @@
 
 @import url('../../keycloak/lib/zocial/zocial.css');
 
+.login-pf {
+    background: #07182B;
+}
+
 .login-pf body {
     background-color: #07182B;
 


### PR DESCRIPTION

Fix the Keycloak background leaking through.

<img width="990" alt="image" src="https://user-images.githubusercontent.com/1196411/149558731-c5e3cd63-d966-4bc7-ba5f-51b5ee464814.png">
