### PR TITLE
feat: add terms of service to registration/login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,33 @@
 
 This project defines the keycloak theme shown on RenkuLab.
 
-# Production
+## Production
 
 In production, the Docker image is mounted into container running Keycloak. See the keycloak section of the helm chart/values file: https://github.com/SwissDataScienceCenter/renku/blob/master/helm-chart/renku/values.yaml. Search for `theme` to find the relevant lines.
 
-# Development
+## Configuration
+
+The theme can be configured to prompt a user to accept the **terms of service** on their first login. This is off by default, but to enable it, modify the following section in `renku-realm.json`:
+
+```
+{
+    "alias": "terms_and_conditions",
+    "name": "Terms and Conditions",
+    "providerId": "terms_and_conditions",
+    "enabled": false,
+    "defaultAction": true,
+    "priority": 20,
+    "config": {}
+}
+```
+
+and set `enabled` to `true`.
+
+```
+"enabled": true,
+```
+
+## Development
 
 For development, there is a `Dockerfile.dev` that can be built and run locally to shorten the feedback loop.
 

--- a/README.md
+++ b/README.md
@@ -8,25 +8,14 @@ In production, the Docker image is mounted into container running Keycloak. See 
 
 ## Configuration
 
-The theme can be configured to prompt a user to accept the **terms of service** on their first login. This is off by default, but to enable it, modify the following section in `renku-realm.json`:
+Keycloak can be configured to prompt a user to accept the **terms of service** on their first login. In Keycloack version 20, this can be done in the admin UI under the `Authentication` section for the realm.
 
-```
-{
-    "alias": "terms_and_conditions",
-    "name": "Terms and Conditions",
-    "providerId": "terms_and_conditions",
-    "enabled": false,
-    "defaultAction": true,
-    "priority": 20,
-    "config": {}
-}
-```
+Select the `Required Actions` tab, make sure `Terms and Conditions` is enabled and set it as default action as well.
 
-and set `enabled` to `true`.
+More details are available in this [stack overflow post](
+https://stackoverflow.com/a/77638989/5804638).
 
-```
-"enabled": true,
-```
+For a Keycloak version different from 20, consult the admin guide, since the configuration may be different.
 
 ## Development
 
@@ -48,6 +37,28 @@ From here, you can click _Sign In_ to get to the login UI.
 
 
 You can make changes to the theme and refresh in your browser to see the updates. You need to do a hard refresh (e.g., Shift-Refresh on Safari) or ensure the cache is disabled to see your changes.
+
+### Configuration
+
+Keycloak can be configured to prompt a user to accept the **terms of service** on their first login. This is off by default, but to enable it, modify the following section in `renku-realm.json`:
+
+```
+{
+    "alias": "terms_and_conditions",
+    "name": "Terms and Conditions",
+    "providerId": "terms_and_conditions",
+    "enabled": false,
+    "defaultAction": true,
+    "priority": 20,
+    "config": {}
+}
+```
+
+and set `enabled` to `true`.
+
+```
+"enabled": true,
+```
 
 ## Local Testing
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ Keycloak can be configured to prompt a user to accept the **terms of service** o
 
 Select the `Required Actions` tab, make sure `Terms and Conditions` is enabled and set it as default action as well.
 
-More details are available in this [stack overflow post](
-https://stackoverflow.com/a/77638989/5804638).
-
 For a Keycloak version different from 20, consult the admin guide, since the configuration may be different.
 
 ## Development

--- a/renku-theme-dev/renku-realm.json
+++ b/renku-theme-dev/renku-realm.json
@@ -1325,7 +1325,7 @@
       "name": "Terms and Conditions",
       "providerId": "terms_and_conditions",
       "enabled": false,
-      "defaultAction": false,
+      "defaultAction": true,
       "priority": 20,
       "config": {}
     },

--- a/renku_theme/login/login.ftl
+++ b/renku_theme/login/login.ftl
@@ -2,8 +2,10 @@
 <@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled??; section>
     <#if section = "header">
         ${msg("loginAccountTitle")}
-        <div id="renku-login-terms-text">
-            ${kcSanitize(msg("termsText"))?no_esc}
+        <div id="renku-login-terms-container">
+            <div id="renku-login-terms-text">
+                ${kcSanitize(msg("termsText"))?no_esc}
+            </div>
         </div>
     <#elseif section = "socialProviders" >
         <#if realm.password && social.providers??>

--- a/renku_theme/login/login.ftl
+++ b/renku_theme/login/login.ftl
@@ -2,6 +2,9 @@
 <@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled??; section>
     <#if section = "header">
         ${msg("loginAccountTitle")}
+        <div id="renku-login-terms-text">
+            ${kcSanitize(msg("termsText"))?no_esc}
+        </div>
     <#elseif section = "socialProviders" >
         <#if realm.password && social.providers??>
             <div id="kc-social-providers" class="${properties.kcFormSocialAccountSectionClass!}">

--- a/renku_theme/login/messages/messages_en.properties
+++ b/renku_theme/login/messages/messages_en.properties
@@ -3,4 +3,4 @@ loginFormLabel=Log in with your RenkuLab account
 
 # Identity provider
 identity-provider-login-label=Sign up or Log in with
-termsText=By continuing, you agree to the RenkuLab <a href="https://renkulab.io/help/tos">Terms of Service</a>.
+termsText=By continuing, you agree to the RenkuLab <a href="https://renkulab.io/help/tos">Terms of Service</a> and acknowledge that the <a href=https://renkulab.io/help/privacy>Privacy Policy</a> applies to you.

--- a/renku_theme/login/messages/messages_en.properties
+++ b/renku_theme/login/messages/messages_en.properties
@@ -3,3 +3,4 @@ loginFormLabel=Log in with your RenkuLab account
 
 # Identity provider
 identity-provider-login-label=Sign up or Log in with
+termsText=By continuing, you agree to the RenkuLab <a href="https://renkulab.io/help/tos">Terms of Service</a>.

--- a/renku_theme/login/messages/messages_en.properties
+++ b/renku_theme/login/messages/messages_en.properties
@@ -3,4 +3,4 @@ loginFormLabel=Log in with your RenkuLab account
 
 # Identity provider
 identity-provider-login-label=Sign up or Log in with
-termsText=By continuing, you agree to the RenkuLab <a href="https://renkulab.io/help/tos">Terms of Service</a> and acknowledge that the <a href=https://renkulab.io/help/privacy>Privacy Policy</a> applies to you.
+termsText=By continuing, you agree to the RenkuLab <a href="/help/tos">Terms of Service</a> and acknowledge that the <a href="/help/privacy">Privacy Policy</a> applies to you.

--- a/renku_theme/login/messages/messages_en.properties
+++ b/renku_theme/login/messages/messages_en.properties
@@ -3,4 +3,4 @@ loginFormLabel=Log in with your RenkuLab account
 
 # Identity provider
 identity-provider-login-label=Sign up or Log in with
-termsText=By continuing, you agree to the RenkuLab <a href="/help/tos">Terms of Service</a> and acknowledge that the <a href="/help/privacy">Privacy Policy</a> applies to you.
+termsText=By continuing, you agree to the RenkuLab <a target="_blank" rel="noreferrer noopener" href="/help/tos">Terms of Service</a> and acknowledge that the <a target="_blank" rel="noreferrer noopener" href="/help/privacy">Privacy Policy</a> applies to you.

--- a/renku_theme/login/register.ftl
+++ b/renku_theme/login/register.ftl
@@ -1,0 +1,146 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('firstName','lastName','email','username','password','password-confirm'); section>
+    <#if section = "header">
+        ${msg("registerTitle")}
+        <div id="renku-login-terms-container">
+            <div id="renku-login-terms-text">
+                ${kcSanitize(msg("termsText"))?no_esc}
+            </div>
+        </div>
+    <#elseif section = "form">
+        <form id="kc-register-form" class="${properties.kcFormClass!}" action="${url.registrationAction}" method="post">
+            <div class="${properties.kcFormGroupClass!}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="firstName" class="${properties.kcLabelClass!}">${msg("firstName")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="text" id="firstName" class="${properties.kcInputClass!}" name="firstName"
+                           value="${(register.formData.firstName!'')}"
+                           aria-invalid="<#if messagesPerField.existsError('firstName')>true</#if>"
+                    />
+
+                    <#if messagesPerField.existsError('firstName')>
+                        <span id="input-error-firstname" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                            ${kcSanitize(messagesPerField.get('firstName'))?no_esc}
+                        </span>
+                    </#if>
+                </div>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="lastName" class="${properties.kcLabelClass!}">${msg("lastName")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="text" id="lastName" class="${properties.kcInputClass!}" name="lastName"
+                           value="${(register.formData.lastName!'')}"
+                           aria-invalid="<#if messagesPerField.existsError('lastName')>true</#if>"
+                    />
+
+                    <#if messagesPerField.existsError('lastName')>
+                        <span id="input-error-lastname" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                            ${kcSanitize(messagesPerField.get('lastName'))?no_esc}
+                        </span>
+                    </#if>
+                </div>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="email" class="${properties.kcLabelClass!}">${msg("email")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="text" id="email" class="${properties.kcInputClass!}" name="email"
+                           value="${(register.formData.email!'')}" autocomplete="email"
+                           aria-invalid="<#if messagesPerField.existsError('email')>true</#if>"
+                    />
+
+                    <#if messagesPerField.existsError('email')>
+                        <span id="input-error-email" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                            ${kcSanitize(messagesPerField.get('email'))?no_esc}
+                        </span>
+                    </#if>
+                </div>
+            </div>
+
+            <#if !realm.registrationEmailAsUsername>
+                <div class="${properties.kcFormGroupClass!}">
+                    <div class="${properties.kcLabelWrapperClass!}">
+                        <label for="username" class="${properties.kcLabelClass!}">${msg("username")}</label>
+                    </div>
+                    <div class="${properties.kcInputWrapperClass!}">
+                        <input type="text" id="username" class="${properties.kcInputClass!}" name="username"
+                               value="${(register.formData.username!'')}" autocomplete="username"
+                               aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"
+                        />
+
+                        <#if messagesPerField.existsError('username')>
+                            <span id="input-error-username" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                                ${kcSanitize(messagesPerField.get('username'))?no_esc}
+                            </span>
+                        </#if>
+                    </div>
+                </div>
+            </#if>
+
+            <#if passwordRequired??>
+                <div class="${properties.kcFormGroupClass!}">
+                    <div class="${properties.kcLabelWrapperClass!}">
+                        <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
+                    </div>
+                    <div class="${properties.kcInputWrapperClass!}">
+                        <input type="password" id="password" class="${properties.kcInputClass!}" name="password"
+                               autocomplete="new-password"
+                               aria-invalid="<#if messagesPerField.existsError('password','password-confirm')>true</#if>"
+                        />
+
+                        <#if messagesPerField.existsError('password')>
+                            <span id="input-error-password" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                                ${kcSanitize(messagesPerField.get('password'))?no_esc}
+                            </span>
+                        </#if>
+                    </div>
+                </div>
+
+                <div class="${properties.kcFormGroupClass!}">
+                    <div class="${properties.kcLabelWrapperClass!}">
+                        <label for="password-confirm"
+                               class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label>
+                    </div>
+                    <div class="${properties.kcInputWrapperClass!}">
+                        <input type="password" id="password-confirm" class="${properties.kcInputClass!}"
+                               name="password-confirm"
+                               aria-invalid="<#if messagesPerField.existsError('password-confirm')>true</#if>"
+                        />
+
+                        <#if messagesPerField.existsError('password-confirm')>
+                            <span id="input-error-password-confirm" class="${properties.kcInputErrorMessageClass!}" aria-live="polite">
+                                ${kcSanitize(messagesPerField.get('password-confirm'))?no_esc}
+                            </span>
+                        </#if>
+                    </div>
+                </div>
+            </#if>
+
+            <#if recaptchaRequired??>
+                <div class="form-group">
+                    <div class="${properties.kcInputWrapperClass!}">
+                        <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"></div>
+                    </div>
+                </div>
+            </#if>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                        <span><a href="${url.loginUrl}">${kcSanitize(msg("backToLogin"))?no_esc}</a></span>
+                    </div>
+                </div>
+
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doRegister")}"/>
+                </div>
+            </div>
+        </form>
+    </#if>
+</@layout.registrationLayout>

--- a/renku_theme/login/resources/css/login.css
+++ b/renku_theme/login/resources/css/login.css
@@ -355,10 +355,16 @@ div#kc-social-providers a:active {
   background-color: #ffffff7d;
 }
 
-div#renku-login-terms-text {
+div#renku-login-terms-container {
+  display: flex;
   font-size: 12px;
-  margin-top: 20px;
   font-weight: normal;
+  margin-top: 20px;
+  justify-content: center;
+}
+
+div#renku-login-terms-text {
+  max-width: 400px;
 }
 
 @media only screen and (max-width: 1080px) {

--- a/renku_theme/login/resources/css/login.css
+++ b/renku_theme/login/resources/css/login.css
@@ -165,7 +165,7 @@ input[type="submit"] {
 }
 
 input[type="submit"]:hover {
-  background: #007A6C;
+  background: #007a6c;
   color: #ffffff;
 }
 
@@ -325,7 +325,7 @@ div#kc-social-providers a {
 }
 
 div#kc-social-providers a:hover {
-  background: #007A6C;
+  background: #007a6c;
   color: #ffffff;
 }
 
@@ -353,6 +353,12 @@ div#kc-social-providers a:active {
   width: 1px;
   height: 110px;
   background-color: #ffffff7d;
+}
+
+div#renku-login-terms-text {
+  font-size: 12px;
+  margin-top: 20px;
+  font-weight: normal;
 }
 
 @media only screen and (max-width: 1080px) {

--- a/renku_theme/login/terms.ftl
+++ b/renku_theme/login/terms.ftl
@@ -1,0 +1,17 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=false; section>
+    <#if section = "header">
+        ${msg("termsTitle")}
+    <#elseif section = "form">
+        <div id="renku-terms-wrapper">
+        <div id="kc-terms-text">
+            ${kcSanitize(msg("termsText"))?no_esc}
+        </div>
+        <form class="form-actions" action="${url.loginAction}" method="POST">
+            <input class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" name="cancel" id="kc-decline" type="submit" value="${msg("doDecline")}"/>
+            <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" name="accept" id="kc-accept" type="submit" value="${msg("doAccept")}"/>
+        </form>
+        <div class="clearfix"></div>
+        </div>
+    </#if>
+</@layout.registrationLayout>


### PR DESCRIPTION
**renku-theme-dev/renku-realm.json**
* configure `terms_and_conditions` as part of the auth flow
* `terms_and_conditions` is disabled by default, but it can be easily enabled.
* formatted document

**renku_theme/login/messages/messages_en.properties**
* text for the terms and conditions page

**renku_theme/login/terms.ftl**
* template for displaying terms and conditions

**renku_theme/ligin/login.ftl**
* Add `By continuing, you agree to the RenkuLab [Terms of Service](https://renkulab.io/help/tos) and acknowledge that the [Privacy Policy](https://renkulab.io/help/privacy) applies to you.` to the login page

<img width="1040" alt="image" src="https://github.com/SwissDataScienceCenter/keycloak-theme/assets/1196411/68eca046-71c5-4924-b01e-fb9fabc7cc3b">


Relates to https://github.com/SwissDataScienceCenter/renku-ui/issues/2954
