### PR TITLE
chore: use non root user in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM busybox
+USER 65534
 COPY renku_theme /renku_theme
 


### PR DESCRIPTION
By default the image uses the root user. But there is no reason for using root.